### PR TITLE
Add cookie/credentials support for network requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -517,6 +517,22 @@
       "dev": true,
       "optional": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "bitmovin-player": {
+      "version": "8.56.0-b.3",
+      "resolved": "https://registry.npmjs.org/bitmovin-player/-/bitmovin-player-8.56.0-b.3.tgz",
+      "integrity": "sha512-+L5jansFsYfhbSARh+Zcp+Iu+xpK/iCb6NgXx9G/6eLzyrdWSuUo7JBXaqVGtJMwpgFbW8pAkWRhvO+aN2A+lA==",
+      "dev": true
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -1612,6 +1628,13 @@
       "integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==",
       "dev": true
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
+    },
     "fill-range": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -2518,6 +2541,13 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
+    },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "dev": true,
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -4037,7 +4067,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -528,9 +528,9 @@
       }
     },
     "bitmovin-player": {
-      "version": "8.56.0-b.3",
-      "resolved": "https://registry.npmjs.org/bitmovin-player/-/bitmovin-player-8.56.0-b.3.tgz",
-      "integrity": "sha512-+L5jansFsYfhbSARh+Zcp+Iu+xpK/iCb6NgXx9G/6eLzyrdWSuUo7JBXaqVGtJMwpgFbW8pAkWRhvO+aN2A+lA==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/bitmovin-player/-/bitmovin-player-8.56.0.tgz",
+      "integrity": "sha512-uJnnQR23tTXr2E/ZbDNvWPEiZiZ4EGEGnjDqmNtTjoBrpJj1u311piCLeMATAfNTim3zFgxEJ82t9odPXKVSPw==",
       "dev": true
     },
     "bluebird": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "devDependencies": {
     "@types/chromecast-caf-receiver": "^5.0.9",
+    "bitmovin-player": "^8.56.0-b.3",
     "html-webpack-plugin": "^4.3.0",
     "prettier": "^2.1.1",
     "ts-loader": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@types/chromecast-caf-receiver": "^5.0.9",
-    "bitmovin-player": "^8.56.0-b.3",
+    "bitmovin-player": "^8.56.0",
     "html-webpack-plugin": "^4.3.0",
     "prettier": "^2.1.1",
     "ts-loader": "^8.0.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { CastReceiverContext, ContentProtection, NetworkRequestInfo, PlayerManager } from 'chromecast-caf-receiver/cast.framework';
 import { LoadRequestData } from 'chromecast-caf-receiver/cast.framework.messages';
-import { CAFMediaInfoCustomData, CAFSourceOptions } from 'bitmovin-player';
+import { CAFDrmConfig, CAFMediaInfoCustomData, CAFSourceOptions } from 'bitmovin-player';
 
 const CAST_MESSAGE_NAMESPACE = 'urn:x-cast:com.bitmovin.player.caf';
 
@@ -35,17 +35,14 @@ export default class CAFReceiver {
       }
 
       if (customData.drm) {
-        return this.setDRM(loadRequestData);
+        this.setDRM(customData.drm);
       }
     }
 
     return loadRequestData;
   };
 
-  private setDRM(loadRequestData: LoadRequestData): LoadRequestData {
-    const customData = loadRequestData.media.customData as CAFMediaInfoCustomData;
-    const { protectionSystem, licenseUrl, headers, withCredentials } = customData.drm;
-
+  private setDRM({ protectionSystem, licenseUrl, headers, withCredentials }: CAFDrmConfig): void {
     this.context.getPlayerManager().setMediaPlaybackInfoHandler((_loadRequest, playbackConfig) => {
       playbackConfig.licenseUrl = licenseUrl;
       playbackConfig.protectionSystem = protectionSystem as ContentProtection;
@@ -62,8 +59,6 @@ export default class CAFReceiver {
 
       return playbackConfig;
     });
-
-    return loadRequestData;
   }
 
   private setWithCredentials(options: CAFSourceOptions): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,6 @@ export default class CAFReceiver {
     this.context.addCustomMessageListener(CAST_MESSAGE_NAMESPACE, this.onCustomMessage);
   }
 
-  // Setup DRM if present in `media.customData`
   private readonly onLoad = (loadRequestData: LoadRequestData): LoadRequestData => {
     const customData = loadRequestData.media.customData as CAFMediaInfoCustomData;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,8 @@ export default class CAFReceiver {
   private setDRM(loadRequestData: LoadRequestData): LoadRequestData {
     const protectionSystem = loadRequestData.media.customData.drm.protectionSystem;
     const licenseUrl = loadRequestData.media.customData.drm.licenseUrl;
+    const withCredentials = loadRequestData.media.customData.drm.withCredentials;
+
     this.context.getPlayerManager().setMediaPlaybackInfoHandler((_loadRequest, playbackConfig) => {
       playbackConfig.licenseUrl = licenseUrl;
       playbackConfig.protectionSystem =  protectionSystem;
@@ -50,6 +52,10 @@ export default class CAFReceiver {
         playbackConfig.licenseRequestHandler = requestInfo => {
           requestInfo.headers = loadRequestData.media.customData.drm.headers;
         };
+      }
+
+      if (withCredentials) {
+        playbackConfig.licenseRequestHandler = setWithCredentialsFlag;
       }
 
       return playbackConfig;

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,12 +66,12 @@ export default class CAFReceiver {
     const playbackConfig = Object.assign(new cast.framework.PlaybackConfig(), playerManager.getPlaybackConfig());
 
     if (options.withCredentials) {
-      playbackConfig.manifestRequestHandler = setWithCredentialsFlag;
+      playbackConfig.segmentRequestHandler = setWithCredentialsFlag;
+      playbackConfig.captionsRequestHandler = setWithCredentialsFlag;
     }
 
     if (options.manifestWithCredentials) {
-      playbackConfig.segmentRequestHandler = setWithCredentialsFlag;
-      playbackConfig.captionsRequestHandler = setWithCredentialsFlag;
+      playbackConfig.manifestRequestHandler = setWithCredentialsFlag;
     }
 
     playerManager.setPlaybackConfig(playbackConfig);

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,14 +28,12 @@ export default class CAFReceiver {
   private readonly onLoad = (loadRequestData: LoadRequestData): LoadRequestData => {
     const customData = loadRequestData.media.customData as CAFMediaInfoCustomData;
 
-    if (customData) {
-      if (customData.options) {
-        this.setWithCredentials(customData.options);
-      }
+    if (customData?.options) {
+      this.setWithCredentials(customData.options);
+    }
 
-      if (customData.drm) {
-        this.setDRM(customData.drm);
-      }
+    if (customData?.drm) {
+      this.setDRM(customData.drm);
     }
 
     return loadRequestData;

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,7 @@ export default class CAFReceiver {
 
     if (options.manifestWithCredentials) {
       playbackConfig.segmentRequestHandler = setWithCredentialsFlag;
+      playbackConfig.captionsRequestHandler = setWithCredentialsFlag;
     }
 
     playerManager.setPlaybackConfig(playbackConfig);


### PR DESCRIPTION
Making use of the `withCredentials` flags that get passed as [`customData`](https://developers.google.com/cast/docs/reference/chrome/chrome.cast.media.MediaInfo#customData) from the sender alongside a load request (*) to enable adding cookies/credentials to various network request types that the receiver performs. This is done by utilizing [request handlers](https://developers.google.com/cast/docs/reference/web_receiver/cast.framework.PlaybackConfig) that the CAF API exposes.

Also, I'm adding the `bitmovin-player` package as a dev dependency to get type definitions for the `cutomData` that's coming from the sender.

(*) feature coming in `bitmovin-player` version 8.56.0