### PR TITLE
[PW-5578] Relay `Seek` / `Seeked` events back to sender

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,6 @@ export default class CAFReceiver {
 
   private attachEvents() {
     this.player.setMessageInterceptor(cast.framework.messages.MessageType.LOAD, this.onLoad);
-    this.player.addEventListener(cast.framework.events.EventType.PLAYING, () => this.relayPlayerEvent(PlayerEvent.Playing));
     this.player.addEventListener(cast.framework.events.EventType.REQUEST_SEEK, () => this.relayPlayerEvent(PlayerEvent.Seek));
     this.player.addEventListener(cast.framework.events.EventType.SEEKED, () => this.relayPlayerEvent(PlayerEvent.Seeked));
     this.context.addCustomMessageListener(CAST_MESSAGE_NAMESPACE, this.onCustomMessage);


### PR DESCRIPTION
The player cast sender needs to know if the receiver is seeking, and when the operation is complete. Also, the UI relies on  such events to update its internal state.
As CAF internally runs a third party player, we need to map the corresponding events to our own `PlayerEvent` values.